### PR TITLE
Fix set_netmask() handling of negative numbers.

### DIFF
--- a/pynetlinux/ifconfig.py
+++ b/pynetlinux/ifconfig.py
@@ -225,7 +225,7 @@ class Interface(object):
     def set_netmask(self, netmask):
         netmask = ctypes.c_uint32(~((2 ** (32 - netmask)) - 1)).value
         nmbytes = socket.htonl(netmask)
-        ifreq = struct.pack('16sH2si8s', self.name, AF_INET, '\x00'*2, nmbytes, '\x00'*8)
+        ifreq = struct.pack('16sH2sI8s', self.name, AF_INET, '\x00'*2, nmbytes, '\x00'*8) 
         fcntl.ioctl(sockfd, SIOCSIFNETMASK, ifreq)
 
 


### PR DESCRIPTION
If the netmask happens to have the first bit set to 1, which is fairly common
(think 255.255.255.0), struct.pack(...i...) will fail, as 'i' takes signed 32
bit integers, and will refuse to take any integer >= 2^31.

The end result is that set_netmask() doesn't work for most netmasks :/

Example:
    >>> struct.pack("i", 2**31)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    struct.error: 'i' format requires -2147483648 <= number <= 2147483647
    >>> struct.pack("i", 2**31 - 1)
    '\0xff\0xff\0xff\0xf7'
