### PR TITLE
Bugfix: current code computes the wrong netmask on some architectures.

### DIFF
--- a/pynetlinux/ifconfig.py
+++ b/pynetlinux/ifconfig.py
@@ -219,7 +219,8 @@ class Interface(object):
             return 0
         netmask = socket.ntohl(struct.unpack('16sH2xI8x', res)[2])
 
-        return 32 - int(math.log(ctypes.c_uint32(~netmask).value + 1, 2))
+        return 32 - int(round(
+            math.log(ctypes.c_uint32(~netmask).value + 1, 2), 1))
 
 
     def set_netmask(self, netmask):


### PR DESCRIPTION
See example below, it prints all possible netmasks with the current code
and fixed code. For network masks like 0xffffffe0, math.log(netmask, 2)
returns 4.99999999 on some architectures, which rounded gives 4, which
in turn leads to a netmask of 28 instead of the correct 27.

See the repeated 31 and 28 in the netmasks below.

```
>>> import math
>>> import ctypes
>>> [32 - int(math.log(ctypes.c_uint32(~(0xffffffff << i)).value + 1, 2)) for i in range(32)]
[32, 31, 31, 29, 28, 28, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
>>> [32 - int(round(math.log(ctypes.c_uint32(~(0xffffffff << i)).value + 1, 2), 1)) for i in range(32)]
[32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
```
